### PR TITLE
refactor: Detailモーダルの削除ボタンのid参照の変更

### DIFF
--- a/task_checker_front/src/components/FormModalBody/DetailBody.vue
+++ b/task_checker_front/src/components/FormModalBody/DetailBody.vue
@@ -80,7 +80,7 @@ onMounted(async()=> {
         編集
       <FormModal v-model="showModal" body="editBody" :task="props.task" @close-modal="closeModal" />
     </button>
-    <button type="button" class="detail_delete_button" @click="DeleteTask(props.task.id)">削除</button>
+    <button type="button" class="detail_delete_button" @click="DeleteTask(task.id)">削除</button>
   </div>
   <form class="comment-from">
     <label for="comment">コメント</label>


### PR DESCRIPTION
# what
idの変数名変更
# why
統一したほうがいい